### PR TITLE
Add more options to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ sitemap-generator --help
     -h, --help                output usage information
     -V, --version             output the version number
     -f, --filepath            path to file including filename
+    -m, --max-entries         limits the maximum number of URLS per sitemap file
+    -d, --max-depth           limits the maximum distance from the original request
     -q, --query               consider query string
     -u, --user-agent <agent>  set custom User Agent
     -v, --verbose             print details when crawling
@@ -66,6 +68,14 @@ Examples:
 - `mymap.xml`
 - `/var/www/sitemap.xml`
 - `./sitemap.myext`
+
+### maxEntries
+
+fine a limit of URLs per sitemap files, useful for site with lots of urls. Defaults to 50000.
+
+### maxDepth
+
+Set a maximum distance from the original request to crawl URLs, useful for generating smaller `sitemap.xml` files. Defaults to 0, which means it will crawl all levels.
 
 ### query
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,16 @@ function sitemapFactory() {
       'path to file including filename',
       'sitemap.xml'
     )
+    .option(
+      '-m, --max-entries <maxEntries>',
+      'limits the maximum number of URLs per sitemap file',
+      50000
+    )
+    .option(
+      '-d, --max-depth <maxDepth>',
+      'limits the maximum distance from the original request',
+      0
+    )
     .option('-q, --query', 'consider query string')
     .option('-u, --user-agent <agent>', 'set custom User Agent')
     .option('-v, --verbose', 'print details when crawling')
@@ -28,7 +38,9 @@ function sitemapFactory() {
 
   const options = {
     stripQuerystring: !program.query,
-    filepath: program.filepath
+    filepath: program.filepath,
+    maxEntriesPerFile: program.maxEntries,
+    maxDepth: program.maxDepth
   };
 
   // only pass if set to keep default


### PR DESCRIPTION
We run into an issue where we couldn't crawl an entire website because it had tons of URLs. Since sitemap-generator has options that could help, limiting the amount of entries and the depth of the crawl, we added those options to the CLI so we could generate partial sitemap.xml files.

Hopefully it will be useful to others as well :)

I didn't find information on how to contribute but the code is pretty straightforward, let me know if I missed anything.

Thanks,